### PR TITLE
[VST-2463] Add support for optional Marketo partner ID

### DIFF
--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -40,6 +40,7 @@ module Mrkt
 
       @client_id = options.fetch(:client_id)
       @client_secret = options.fetch(:client_secret)
+      @partner_id = options[:partner_id]
 
       @retry_authentication = options.fetch(:retry_authentication, false)
       @retry_authentication_count = options.fetch(:retry_authentication_count, 3).to_i

--- a/lib/mrkt/concerns/authentication.rb
+++ b/lib/mrkt/concerns/authentication.rb
@@ -29,8 +29,6 @@ module Mrkt
 
     def authenticate
       connection.get('/identity/oauth/token', authentication_params).tap do |response|
-        puts response.body
-
         data = response.body
 
         @token = data.fetch(:access_token)

--- a/lib/mrkt/concerns/authentication.rb
+++ b/lib/mrkt/concerns/authentication.rb
@@ -39,15 +39,27 @@ module Mrkt
     end
 
     def authentication_params
-      {
-        grant_type: 'client_credentials',
-        client_id: @client_id,
-        client_secret: @client_secret
-      }
+      merge_params(required_authentication_params, optional_authentication_params)
     end
 
     def add_authorization(req)
       req.headers[:authorization] = "Bearer #{@token}"
+    end
+
+    private
+
+    def optional_authentication_params
+      {
+          partner_id: @partner_id
+      }
+    end
+
+    def required_authentication_params
+      {
+          grant_type: 'client_credentials',
+          client_id: @client_id,
+          client_secret: @client_secret
+      }
     end
   end
 end

--- a/lib/mrkt/concerns/authentication.rb
+++ b/lib/mrkt/concerns/authentication.rb
@@ -29,6 +29,8 @@ module Mrkt
 
     def authenticate
       connection.get('/identity/oauth/token', authentication_params).tap do |response|
+        puts response.body
+
         data = response.body
 
         @token = data.fetch(:access_token)

--- a/spec/concerns/authentication_spec.rb
+++ b/spec/concerns/authentication_spec.rb
@@ -29,6 +29,35 @@ describe Mrkt::Authentication do
       expect(client.authenticated?).to be true
     end
 
+    context 'with optional partner_id client option' do
+      before { remove_request_stub(@authentication_request_stub) }
+
+      let(:partner_id) { SecureRandom.uuid }
+
+      let(:client_options) do
+        {
+            host: host,
+            client_id: client_id,
+            client_secret: client_secret,
+            partner_id: partner_id
+        }
+      end
+
+      subject(:client) { Mrkt::Client.new(client_options) }
+
+      before do
+        stub_request(:get, "https://#{host}/identity/oauth/token")
+            .with(query: { client_id: client_id, client_secret: client_secret, partner_id: partner_id, grant_type: 'client_credentials' })
+            .to_return(json_stub(authentication_stub))
+      end
+
+      it 'should authenticate and then be authenticated?' do
+        expect(client.authenticated?).to_not be true
+        client.authenticate!
+        expect(client.authenticated?).to be true
+      end
+    end
+
     context 'when the token has expired and @retry_authentication = true' do
       before { remove_request_stub(@authentication_request_stub) }
 


### PR DESCRIPTION
Visibility PR.

This change adds support for the required partner_id parameter for Marketo auth per [their documentation](http://developers.marketo.com/support/Marketo_LaunchPoint_Technology_Partner_API_Key.pdf).
